### PR TITLE
Add new blog post: How Software Architects Build Confidence

### DIFF
--- a/_posts/2026-06-15-how-architects-build-confidence.md
+++ b/_posts/2026-06-15-how-architects-build-confidence.md
@@ -1,0 +1,44 @@
+---
+layout: post
+title: 'How Software Architects Build Confidence'
+date: 2026-06-15
+categories:
+---
+
+I've been an individual contributor, a manager, and an architect throughout my career. One thing has remained consistent across all of those roles: I've always enjoyed being hands-on.
+
+Part of that is simply how I'm wired. I've always been a tinkerer. I enjoy understanding how things work under the hood. Whether it's software, technology, or even a LEGO set, I've always found myself drawn to building, experimenting, and seeing how individual pieces come together to create something larger.
+
+That curiosity has followed me throughout my career. As I've moved into architecture roles, it hasn't disappeared. If anything, it's become one of the ways I learn, explore ideas, and validate assumptions.
+
+Over the years, I've occasionally heard debates about whether architects should code, prototype, or remain close to implementation. The conversation often turns into two opposing camps. One argues that architects should focus on strategy and design while engineers focus on implementation. The other argues that architects who aren't hands-on risk becoming disconnected from reality.
+
+I've never found either position particularly helpful.
+
+For me, staying hands-on has never been about a lack of trust in engineers. In fact, some of the strongest engineers I've worked with have taught me things I never would have discovered on my own. Staying hands-on isn't about checking their work or proving that I can do it myself. It's about understanding the problem deeply enough to make better architectural decisions.
+
+Nor do I believe architects need to own implementation. Engineering teams are ultimately responsible for building and operating solutions at scale.
+
+What I've come to realize is that my desire to stay hands-on is really about validation.
+
+Architecture is fundamentally a series of decisions and assumptions. We make predictions about how systems will behave, how teams will operate, how technology will scale, and how solutions will evolve over time. The role of an architect is not simply to create diagrams or standards. The role is to create confidence that those decisions will lead to successful outcomes.
+
+Traditionally, architects have validated decisions through experience, patterns, reference architectures, design reviews, and governance processes. Those approaches remain valuable and necessary.
+
+At the same time, modern technology environments are increasingly defined by uncertainty. New platforms emerge. AI changes workflows. Organizational structures evolve. Business expectations shift faster than they once did.
+
+In these situations, implementation can become another form of validation.
+
+A proof of concept, prototype, spike, or reference implementation can reveal constraints, assumptions, and opportunities that may not be visible from a design document alone. Sometimes the fastest way to learn whether an idea is sound is to build enough of it to see how it behaves.
+
+This doesn't mean architects should become full-time implementers. There is a balance. The higher an architect's scope and responsibilities become, the more important it is to focus on strategy, alignment, and long-term direction.
+
+However, I do believe an architect's level of hands-on involvement should be proportional to the uncertainty of the problem being solved.
+
+When uncertainty is low, experience and established patterns may be sufficient. When uncertainty is high, experimentation and implementation may provide the validation needed to move forward with confidence.
+
+Perhaps that's why I've always remained hands-on throughout my career. Not because architecture requires implementation. Not because engineers need oversight. But because implementation has often been one of the most effective ways to validate assumptions, reduce risk, and improve architectural decisions.
+
+The goal has never been to own the code.
+
+The goal has always been to create confidence that the architecture will succeed.

--- a/_posts/2026-06-15-how-architects-build-confidence.md
+++ b/_posts/2026-06-15-how-architects-build-confidence.md
@@ -5,7 +5,7 @@ date: 2026-06-15
 categories:
 ---
 
-I've been an individual contributor, a manager, and an architect throughout my career. One thing has remained consistent across all of those roles: I've always enjoyed being hands-on.
+Throughout my career in software engineering, I've been an individual contributor, a manager, and an architect. One thing has remained consistent across all of those roles: I've always enjoyed being hands-on.
 
 Part of that is simply how I'm wired. I've always been a tinkerer. I enjoy understanding how things work under the hood. Whether it's software, technology, or even a LEGO set, I've always found myself drawn to building, experimenting, and seeing how individual pieces come together to create something larger.
 


### PR DESCRIPTION
New blog post reflecting on why staying hands-on as an architect is really about validation and building confidence in architectural decisions.